### PR TITLE
[Refactor] NFC: unify peer handlers into one handler

### DIFF
--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -1,25 +1,18 @@
 use crate::proto::socks5::Command;
 use thiserror::Error;
 
-/// Bails out with unsupported error
-macro_rules! unsupported {
-    ($x:expr) => {
-        bail!(LurkError::Unsupported($x))
-    };
-}
-
-pub(crate) use unsupported;
-
 #[derive(Error, Debug, PartialEq)]
 pub enum LurkError {
     #[error("data has incorrect / corrupted field: {0}")]
     DataError(InvalidValue),
     #[error("failed UTF-8 decoding of domain name: {0}")]
     DomainNameDecodingFailed(std::string::FromUtf8Error),
-    #[error("{0} is not supported")]
-    Unsupported(Unsupported),
+    #[error("SOCKS command {0:?} is not supported")]
+    UnsupportedSocksCommand(Command),
     #[error("unable to resolve domain name {0}")]
     UnresolvedDomainName(String),
+    #[error("unable to select appropriate authentication method")]
+    NoAcceptableAuthMethod
 }
 
 #[derive(Error, Debug, PartialEq)]
@@ -34,10 +27,4 @@ pub enum InvalidValue {
     AuthMethod(u8),
     #[error("invalid SOCKS command {0:#02x}")]
     SocksCommand(u8),
-}
-
-#[derive(Error, Debug, PartialEq)]
-pub enum Unsupported {
-    #[error("{0:?} SOCKS5 command")]
-    Socks5Command(Command),
 }

--- a/src/proto/socks5/mod.rs
+++ b/src/proto/socks5/mod.rs
@@ -5,7 +5,7 @@
 /// https://datatracker.ietf.org/doc/html/rfc1928#ref-1
 ///
 use crate::common::{
-    error::{InvalidValue, LurkError, Unsupported},
+    error::{InvalidValue, LurkError},
     net::Address,
     LurkAuthMethod,
 };
@@ -161,9 +161,7 @@ impl ReplyStatus {
 impl From<LurkError> for ReplyStatus {
     fn from(err: LurkError) -> Self {
         match err {
-            LurkError::Unsupported(unsupported) => match unsupported {
-                Unsupported::Socks5Command(_) => ReplyStatus::CommandNotSupported,
-            },
+            LurkError::UnsupportedSocksCommand(_) => ReplyStatus::CommandNotSupported,
             LurkError::UnresolvedDomainName(_) => ReplyStatus::HostUnreachable,
             _ => ReplyStatus::GeneralFailure,
         }

--- a/src/proto/socks5/test.rs
+++ b/src/proto/socks5/test.rs
@@ -1,6 +1,6 @@
 use crate::{
     common::{
-        error::{InvalidValue, LurkError, Unsupported},
+        error::{InvalidValue, LurkError},
         net::ipv4_socket_address,
         LurkAuthMethod,
     },
@@ -158,7 +158,7 @@ fn error_to_relay_status_cast() {
     let dummy_invalid_value_err = InvalidValue::AuthMethod(0xff);
     let dummy_utf8_err = String::from_utf8(vec![0xF1]).unwrap_err();
 
-    assert_eq!(ReplyStatus::CommandNotSupported,     anyhow!(LurkError::Unsupported(Unsupported::Socks5Command(Command::TCPBind))).into());
+    assert_eq!(ReplyStatus::CommandNotSupported,     anyhow!(LurkError::UnsupportedSocksCommand(Command::TCPBind)).into());
     assert_eq!(ReplyStatus::GeneralFailure,          anyhow!(LurkError::DataError(dummy_invalid_value_err)).into());
     assert_eq!(ReplyStatus::GeneralFailure,          anyhow!(LurkError::DomainNameDecodingFailed(dummy_utf8_err)).into());
     assert_eq!(ReplyStatus::ConnectionRefused,       anyhow!(io::Error::from(io::ErrorKind::ConnectionRefused)).into());

--- a/src/server/peer/auth.rs
+++ b/src/server/peer/auth.rs
@@ -45,13 +45,14 @@ impl LurkAuthenticator {
 
     /// Find any common authentication method between available
     /// auth methods on server and supported methods by client.
-    pub fn select_auth_method(&mut self, peer_methods: &HashSet<LurkAuthMethod>) {
+    pub fn select_auth_method(&mut self, peer_methods: &HashSet<LurkAuthMethod>) -> Option<LurkAuthMethod> {
         let common_methods = self
             .available_methods
             .intersection(peer_methods)
             .collect::<HashSet<&LurkAuthMethod>>();
 
         self.selected_method = common_methods.into_iter().nth(0).copied();
+        self.selected_method
     }
 
     pub fn current_method(&self) -> Option<LurkAuthMethod> {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -41,6 +41,7 @@ async fn http_server_single_client() {
     assert_eq!(200, response.status());
 
     lurk_handle.abort();
+    drop(http_server);
     sleep(Duration::from_millis(1000));
 }
 
@@ -48,10 +49,10 @@ async fn http_server_single_client() {
 async fn echo_server_multiple_clients() {
     common::init_logging();
 
-    let num_clients = 2;
-    let generated_data_len = 128;
-    let lurk_server_addr = "127.0.0.1:32001".parse::<SocketAddr>().unwrap();
-    let echo_server_addr = "127.0.0.1:32003".parse::<SocketAddr>().unwrap();
+    let num_clients = 100;
+    let generated_data_len = 1024;
+    let lurk_server_addr = "127.0.0.1:32003".parse::<SocketAddr>().unwrap();
+    let echo_server_addr = "127.0.0.1:32004".parse::<SocketAddr>().unwrap();
 
     // Run Lurk proxy.
     let lurk_handle = common::spawn_lurk_server(lurk_server_addr).await;


### PR DESCRIPTION
This change is intended to be non-functional. All handlers dedicated for SOCKS5 peer were unified into one LurkPeerHandler.

LurkConnectionHandler was removed from server module.