### PR TITLE
[Refactor] Add helper routine to establish TCP connection

### DIFF
--- a/src/common/net.rs
+++ b/src/common/net.rs
@@ -1,11 +1,16 @@
 use crate::common::error::LurkError;
 use anyhow::{anyhow, Result};
 use bytes::BufMut;
+use log::{debug, trace};
+use socket2::{SockRef, TcpKeepalive};
 use std::{
     fmt::Display,
     net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
 };
-use tokio::{io::AsyncReadExt, net::lookup_host};
+use tokio::{
+    io::AsyncReadExt,
+    net::{lookup_host, TcpStream},
+};
 
 macro_rules! ipv4_socket_address {
     ($ipv4:expr, $port:expr) => {
@@ -84,6 +89,58 @@ impl Address {
     pub fn write_domain_name<T: BufMut>(bytes: &mut T, name: &str, port: &u16) {
         todo!("Writing of domain names is not implemented")
     }
+}
+
+/// Different TCP connection options.
+///
+/// **Fields**:
+/// * ```keep_alive``` - setting for TCP keepalive procedure
+///
+///
+pub struct TcpConnectionOptions {
+    keep_alive: Option<TcpKeepalive>,
+}
+
+impl TcpConnectionOptions {
+    pub fn new() -> TcpConnectionOptions {
+        TcpConnectionOptions { keep_alive: None }
+    }
+
+    pub fn set_keepalive(&mut self, keep_alive: TcpKeepalive) -> &mut TcpConnectionOptions {
+        debug_assert!(self.keep_alive.is_none(), "should be unset");
+        self.keep_alive = Some(keep_alive);
+        self
+    }
+
+    pub fn apply_to(&self, tcp_stream: &mut TcpStream) -> Result<()> {
+        let tcp_sock_ref = SockRef::from(&tcp_stream);
+
+        if let Some(keep_alive) = &self.keep_alive {
+            tcp_sock_ref.set_tcp_keepalive(keep_alive)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Establish TCP connection with passed ```endpoint```.
+///
+/// Input ```tcp_opts``` are applied to created TCP socket right after stream creation.
+pub async fn establish_tcp_connection_with_opts(endpoint: &Address, tcp_opts: &TcpConnectionOptions) -> Result<TcpStream> {
+    // Resolve endpoint address.
+    trace!("Endpoint address {} resolution: ... ", endpoint);
+    let resolved = endpoint.to_socket_addr().await?;
+    trace!("Endpoint address {} resolution: SUCCESS with {}", endpoint, resolved);
+
+    // Establish TCP connection with the endpoint.
+    debug!("TCP connection establishment with the endpoint {}: ... ", endpoint);
+    let mut tcp_stream = TcpStream::connect(resolved).await.map_err(anyhow::Error::from)?;
+    debug!("TCP connection establishment with the endpoint {}: SUCCESS", endpoint);
+
+    // Apply passed options to created TCP stream.
+    tcp_opts.apply_to(&mut tcp_stream)?;
+
+    Ok(tcp_stream)
 }
 
 impl Display for Address {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -24,10 +24,7 @@ impl LurkServer {
         let tcp_listener = self.bind().await?;
         loop {
             match tcp_listener.accept().await {
-                Ok((stream, addr)) => {
-                    log_opened_tcp_conn!(addr);
-                    self.on_new_peer_connected(stream, addr).await
-                }
+                Ok((stream, addr)) => self.on_tcp_connection_established(stream, addr).await,
                 Err(err) => warn!("Error while accepting the TCP connection: {}", err),
             }
         }
@@ -40,7 +37,8 @@ impl LurkServer {
         Ok(tcp_listener)
     }
 
-    async fn on_new_peer_connected(&self, stream: TcpStream, addr: SocketAddr) {
+    async fn on_tcp_connection_established(&self, stream: TcpStream, addr: SocketAddr) {
+        log_opened_tcp_conn!(addr);
         // Identify peer type.
         let peer_type = match LurkPeerType::from_tcp_stream(&stream).await {
             Ok(t) => {


### PR DESCRIPTION
This adds auxiliary routine to "net" module in order to establish TCP connection with passed options.