### PR TITLE
Eliminate backpressure

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<()> {
 
     // Create proxy server instance. It will handle incoming connection in async. fashion.
     let server_addr = SocketAddr::new(IpAddr::V4(config.bind_ipv4()), config.bind_port());
-    let server = LurkServer::new(server_addr, config.tcp_conn_limit());
+    let server = LurkServer::new(server_addr);
 
     // Bind and serve clients "forever"
     server.run().await?;

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -161,11 +161,10 @@ mod tests {
 
     // :0 tells the OS to pick an open port.
     const TEST_BIND_IPV4: &str = "127.0.0.1:0";
-    const TEST_CONN_LIMIT: usize = 1024;
 
     #[tokio::test]
     async fn socks5_handshake_with_auth_method() {
-        let mut listener = LurkTcpListener::bind(TEST_BIND_IPV4, TEST_CONN_LIMIT)
+        let mut listener = LurkTcpListener::bind(TEST_BIND_IPV4)
             .await
             .expect("Expect binded listener");
 
@@ -206,7 +205,7 @@ mod tests {
 
     #[tokio::test]
     async fn socks5_handshake_with_non_accepatable_method() {
-        let mut listener = LurkTcpListener::bind(TEST_BIND_IPV4, TEST_CONN_LIMIT)
+        let mut listener = LurkTcpListener::bind(TEST_BIND_IPV4)
             .await
             .expect("Expect binded listener");
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -16,7 +16,6 @@ mod handlers;
 
 pub struct LurkServer {
     bind_addr: SocketAddr,
-    conn_limit: usize,
 }
 
 impl LurkServer {
@@ -24,13 +23,13 @@ impl LurkServer {
     /// handle resource exhaustion errors.
     const DELAY_AFTER_ERROR_MILLIS: u64 = 500;
 
-    pub fn new(bind_addr: SocketAddr, conn_limit: usize) -> LurkServer {
-        LurkServer { bind_addr, conn_limit }
+    pub fn new(bind_addr: SocketAddr) -> LurkServer {
+        LurkServer { bind_addr }
     }
 
     pub async fn run(&self) -> Result<()> {
-        let mut tcp_listener = LurkTcpListener::bind(self.bind_addr, self.conn_limit).await?;
-        info!("Listening on {} (TCP connections limit {})", self.bind_addr, self.conn_limit);
+        let mut tcp_listener = LurkTcpListener::bind(self.bind_addr).await?;
+        info!("Listening on {}", self.bind_addr);
 
         loop {
             match tcp_listener.accept().await {

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -14,10 +14,10 @@ pub fn init_logging() {
 }
 
 /// Spawn Lurk proxy instance.
-pub async fn spawn_lurk_server(addr: SocketAddr, tcp_conn_limit: usize) -> tokio::task::JoinHandle<()> {
+pub async fn spawn_lurk_server(addr: SocketAddr) -> tokio::task::JoinHandle<()> {
     // Run proxy
     let handle = tokio::spawn(async move {
-        LurkServer::new(addr, tcp_conn_limit)
+        LurkServer::new(addr)
             .run()
             .await
             .expect("Error during proxy server run")

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -15,7 +15,7 @@ async fn http_server_single_client() {
     let http_server_addr = "127.0.0.1:32002".parse::<SocketAddr>().unwrap();
 
     // Run proxy
-    let lurk_handle = common::spawn_lurk_server(lurk_server_addr, 1024).await;
+    let lurk_handle = common::spawn_lurk_server(lurk_server_addr).await;
 
     // Run HTTP server in the background
     let http_server = ServerBuilder::new()
@@ -55,7 +55,7 @@ async fn echo_server_multiple_clients() {
     let echo_server_addr = "127.0.0.1:32004".parse::<SocketAddr>().unwrap();
 
     // Run Lurk proxy.
-    let lurk_handle = common::spawn_lurk_server(lurk_server_addr, 1024).await;
+    let lurk_handle = common::spawn_lurk_server(lurk_server_addr).await;
 
     // Run echo server. Data sent to this server will be proxied through Lurk
     // instance spawned above.


### PR DESCRIPTION
It turned out to be not straightforward to implement backpressure of TCP connections. Reverting TCP backpressure logic to ease debuggability of existing logic.