### PR TITLE
[HTTP endpoint] Introduce endpoint for providing node status

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,13 @@ async-listen = { version = "0.2.1" }
 bytes = { version = "1.6.0" }
 clap = { version = "4.5.3", features = ["derive"] }
 cfg-if = { version = "1.0" }
+chrono = { version = "^0.4", features = ["serde"]}
 human_bytes = { version = "0.4.3" }
 hyper = { version = "1.3.1", features = ["server"] }
 hyper-util = { version = "0.1.5", features = ["full"] }
+serde = { version = "^1.0", features = ["derive"] }
+serde_json = { version = "^1.0" }
+serde_with = { version = "^3.9", features = ["chrono_0_4"]}
 http-body-util = { version = "0.1.2" }
 log = { version = "0.4.21" }
 log4rs = { version = "1.3.0" }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,60 +1,144 @@
-use crate::net::tcp;
+use crate::{net::tcp, server::LurkServer};
 use anyhow::Result;
 use bytes::Bytes;
+use chrono::{DateTime, TimeDelta, Utc};
 use http_body_util::Full;
 use hyper::{
     body::{self},
     server::conn::http1,
-    service::service_fn,
+    service::Service,
     Request, Response, StatusCode,
 };
-use hyper_util::rt::TokioIo;
-use log::{debug, info, trace};
+use hyper_util::rt::{TokioIo, TokioTimer};
+use log::{debug, error, info, log_enabled, trace};
+use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DurationSeconds};
 use std::{
-    convert::Infallible,
+    future::Future,
     net::{SocketAddr, ToSocketAddrs},
+    pin::Pin,
+    sync::Arc,
 };
 use tokio::net::TcpListener;
 
 pub struct LurkHttpEndpoint {
     addr: SocketAddr,
+    service: LurkHttpService,
 }
 
 impl LurkHttpEndpoint {
-    pub fn new(addr: impl ToSocketAddrs) -> LurkHttpEndpoint {
+    pub fn new(addr: impl ToSocketAddrs, node: Arc<LurkServer>) -> LurkHttpEndpoint {
         LurkHttpEndpoint {
             addr: tcp::resolve_sockaddr(addr),
+            service: LurkHttpService { node },
         }
     }
 
-    /// Synchronously serve incoming HTTP requests.
+    /// Asynchronously serve incoming HTTP requests.
     pub async fn run(&self) -> Result<()> {
         let listener = TcpListener::bind(self.addr).await?;
         info!("HTTP endpoint is listening on {}", self.addr);
 
-        // Create HTTP server builder.
-        let http_builder = http1::Builder::new();
-
         loop {
             let (tcp_stream, client_addr) = listener.accept().await?;
             let io = TokioIo::new(tcp_stream);
+            let service = self.service.clone();
 
-            trace!("Handling incoming HTTP request from {}", client_addr);
-            http_builder
-                .serve_connection(io, service_fn(LurkHttpEndpoint::request_handler))
-                .await?;
+            debug!("Incoming HTTP request from {}", client_addr);
+
+            tokio::spawn(async move {
+                // Handle the connection from the client using HTTP1 and pass any
+                // HTTP requests received on that connection to the service.
+                if let Err(err) = http1::Builder::new().timer(TokioTimer::new()).serve_connection(io, service).await {
+                    error!("Error occured while handling HTTP request from {client_addr:}: {err:?}");
+                }
+            });
+        }
+    }
+}
+
+#[derive(Clone)]
+struct LurkHttpService {
+    node: Arc<LurkServer>,
+}
+
+impl Service<Request<body::Incoming>> for LurkHttpService {
+    type Error = anyhow::Error;
+    type Response = Response<Full<Bytes>>;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn call(&self, request: Request<body::Incoming>) -> Self::Future {
+        let uri_path = request.uri().path();
+
+        // Dump full request data if trace is enabled
+        if log_enabled!(log::Level::Trace) {
+            trace!("{:?}", request);
+        } else {
+            info!("{:?} {} '{}'", request.version(), request.method(), uri_path);
+        }
+
+        let response = match uri_path {
+            "/healthcheck" => {
+                let node_status = LurkNodeStatus::build(&self.node);
+                trace!("Response to '{uri_path}': {node_status:?}");
+                Response::builder()
+                    .header("Content-Type", "application/json")
+                    .body(node_status.serialize_as_body_chunk())
+            }
+            _ => Response::builder()
+                .status(StatusCode::NOT_IMPLEMENTED)
+                .body(Full::new(Bytes::new())),
+        };
+
+        Box::pin(async { Ok(response.unwrap()) })
+    }
+}
+
+/// Structure describing node health status sent as HTTP response.
+#[serde_as]
+#[derive(Serialize, Deserialize, Debug)]
+struct LurkNodeStatus {
+    /// Timespan between "started" and "current" timestamps.
+    #[serde_as(as = "Option<DurationSeconds<i64>>")]
+    uptime_secs: Option<TimeDelta>,
+
+    /// UTC timestamp made when node started to accept connections.
+    started_utc_ts: Option<DateTime<Utc>>,
+}
+
+impl LurkNodeStatus {
+    /// Fill status structure depending on the information retrived
+    /// from input node.
+    fn build(node: &LurkServer) -> LurkNodeStatus {
+        let node_stats = node.get_stats();
+        let mut uptime_secs = None;
+        let mut started_utc_ts = None;
+
+        if node_stats.is_server_started() {
+            uptime_secs = Some(node_stats.get_uptime());
+            started_utc_ts = Some(node_stats.get_started_utc_timestamp());
+        }
+
+        LurkNodeStatus {
+            uptime_secs,
+            started_utc_ts,
         }
     }
 
-    async fn request_handler(req: Request<body::Incoming>) -> Result<Response<Full<Bytes>>, Infallible> {
-        debug!("Handling incoming {req:?}");
-
-        let response = Response::builder();
-        let response = match req.uri().path() {
-            "/healthcheck" => response.status(StatusCode::OK).body(Full::new(Bytes::new())),
-            _ => response.status(StatusCode::NOT_IMPLEMENTED).body(Full::new(Bytes::new())),
+    /// Try to serialize input data. Returns serialized bytes on succes.
+    /// On failure, empty bytes is returned.
+    fn serialize_as_body_chunk(&self) -> Full<Bytes> {
+        let bytes = match serde_json::to_string(&self) {
+            Ok(bytes) => Bytes::from(bytes),
+            Err(err) => {
+                error!(
+                    "Error occured during body serialization: {err:?}.
+                    Empty body has been returned."
+                );
+                Bytes::new()
+            }
         };
 
-        Ok(response.unwrap())
+        Full::new(bytes)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use anyhow::Result;
 use clap::Parser;
 use log::error;
@@ -17,11 +18,13 @@ async fn main() -> Result<()> {
     let lurk_config = LurkConfig::parse();
 
     // Create proxy server instance. It will handle incoming connection in async. fashion.
-    let server = LurkServer::new(lurk_config.server_tcp_bind_addr());
+    let server = Arc::new(LurkServer::new(lurk_config.server_tcp_bind_addr()));
 
     // Spin up HTTP endpoint if enabled
     if let Some(http_endpoint_bind_addr) = lurk_config.http_endpoint_bind_addr() {
-        let http_endpoint = LurkHttpEndpoint::new(http_endpoint_bind_addr);
+        // Create endpoint and pass atomic reference to created server instance. Endpoint will
+        // communicate to server through provided interface (e.g. ask some metrics).
+        let http_endpoint = LurkHttpEndpoint::new(http_endpoint_bind_addr, Arc::clone(&server));
         tokio::spawn(async move {
             if let Err(err) = http_endpoint.run().await {
                 error!("Error occured while HTTP endpoint was running: {}", err);

--- a/src/server/stats.rs
+++ b/src/server/stats.rs
@@ -1,0 +1,53 @@
+use chrono::{DateTime, Duration, Utc};
+use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
+
+pub struct LurkServerStats {
+    is_started: AtomicBool,
+    started_ts_millis: AtomicI64,
+}
+
+impl LurkServerStats {
+    pub fn new() -> LurkServerStats {
+        LurkServerStats {
+            started_ts_millis: AtomicI64::new(0),
+            is_started: AtomicBool::new(false),
+        }
+    }
+
+    /// Called when node is started to accept connections.
+    pub fn on_server_started(&self) {
+        assert!(!self.is_started.load(Ordering::Relaxed), "server shoudn't be started yet");
+        let current_time = Utc::now();
+
+        self.is_started.store(true, Ordering::Relaxed);
+        self.started_ts_millis.store(current_time.timestamp_millis(), Ordering::Relaxed);
+    }
+
+    /// Returns true if server is started.
+    /// There's no guarantee it hasn't finished yet.
+    pub fn is_server_started(&self) -> bool {
+        self.is_started.load(Ordering::Relaxed)
+    }
+
+    /// Returns time past since server is started.
+    pub fn get_uptime(&self) -> Duration {
+        assert!(self.is_started.load(Ordering::Relaxed), "server should be already started");
+        let current_ts = Utc::now();
+        let started_ts = self.get_started_utc_timestamp();
+
+        assert!(current_ts >= started_ts);
+        current_ts - started_ts
+    }
+
+    /// Returns UTC timestamp describing server start time.
+    pub fn get_started_utc_timestamp(&self) -> DateTime<Utc> {
+        assert!(self.is_started.load(Ordering::Relaxed), "server should be already started");
+        DateTime::from_timestamp_millis(self.started_ts_millis.load(Ordering::Relaxed)).expect("valid datetime")
+    }
+}
+
+impl Default for LurkServerStats {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,8 +1,10 @@
 use futures::{stream::FuturesUnordered, StreamExt};
 use httptest::{matchers::request::method_path, responders::status_code, Expectation, ServerBuilder};
+use hyper::StatusCode;
 use log::info;
 use pretty_assertions::assert_eq;
 use reqwest::ClientBuilder;
+use serde_json::{json, Value};
 use std::{net::SocketAddr, thread::sleep, time::Duration};
 
 mod common;
@@ -77,5 +79,32 @@ async fn echo_server_multiple_clients() {
     echo_handle.abort();
     lurk_handle.abort();
 
+    sleep(Duration::from_millis(1000));
+}
+
+#[tokio::test]
+async fn http_healthcheck() {
+    common::init_logging();
+
+    let http_endpoint_addr = "127.0.0.1:32005".parse::<SocketAddr>().unwrap();
+    let http_endpoint = common::spawn_http_api_endpoint(http_endpoint_addr).await;
+
+    let http_client = ClientBuilder::new().build().expect("Unable to build HTTP client");
+
+    let response = http_client
+        .get(format!("http://{}/healthcheck", http_endpoint_addr))
+        .send()
+        .await
+        .expect("Unable to send healthcheck GET request");
+
+    assert_eq!(StatusCode::OK, response.status());
+
+    let body_bytes = response.bytes().await.unwrap();
+    let body_value: Value = serde_json::from_slice(&body_bytes).unwrap();
+
+    assert_eq!(*body_value.get("uptime_secs").unwrap(), json!(null));
+    assert_eq!(*body_value.get("started_utc_ts").unwrap(), json!(null));
+
+    http_endpoint.abort();
     sleep(Duration::from_millis(1000));
 }


### PR DESCRIPTION
This is a major change that includes the following items:

* Endpoint responds to /healthcheck URI path with a) "started" UTC timestamp; b) "uptime" seconds. Data packed as JSON in HTTP response body.
* Server now has separate LurkServerStats instance for tracking of statistics
* HTTP endpoint handles requests asynchronously
* HTTP endpoint has atomic reference to server instance